### PR TITLE
Stop Xcode from crashing, no longer need to quit Xcode to run kit update

### DIFF
--- a/Kit/Util/FSAction.hs
+++ b/Kit/Util/FSAction.hs
@@ -18,7 +18,8 @@ within = InDir
 runAction :: FSAction -> IO ()
 runAction (FileCreate atPath contents) = do
   mkdirP $ dropFileName atPath 
-  writeFile atPath contents
+  writeFile (atPath ++ "_") contents
+  renameFile (atPath ++ "_") atPath
 runAction (Symlink target name) = do
   catch (removeLink name) (\_ -> return ())
   -- When a `name` has parent directories, symbolic link target needs to be made relative to that file


### PR DESCRIPTION
This pull request stops Xcode from crashing and allows running kit update while the parent project is open.

Was only indending to atomically write just the project file but the following are also written the same way:

KitDeps.xcodeproj/project.pbxproj
Prefix.pch
Kit.xcconfig
Makefile
DepsOnly.xcconfig
