### PR TITLE
Added support for Mac OS X kits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.7.13
+-----
+* Added support for Mac OS X kits
+
 0.7.7
 -----
 * No longer crashes Xcode when a new kit project is generated.

--- a/Kit/Project.hs
+++ b/Kit/Project.hs
@@ -34,9 +34,13 @@ kitUpdateMakeFile = "kit: Kit.xcconfig\n" ++
                     "\tcd .. && kit update && exit 1\n"
 
 prefixDefault :: String
-prefixDefault = "#ifdef __OBJC__\n" ++ 
-                "    #import <Foundation/Foundation.h>\n" ++ 
-                "    #import <UIKit/UIKit.h>\n" ++ 
+prefixDefault = "#ifdef __OBJC__\n" ++
+                "    #import <Foundation/Foundation.h>\n" ++
+                "    #if TARGET_OS_MAC\n" ++
+                "        #import <Cocoa/Cocoa.h>\n" ++
+                "    #else\n" ++
+                "        #import <UIKit/UIKit.h>\n" ++
+                "    #endif\n" ++
                 "#endif\n"
 
 data KitProject = KitProject {
@@ -68,7 +72,7 @@ makeKitProject kitsContents depsOnlyConfig =
       header = createHeader kitsContents
       config = createConfig kitsContents
       -- TODO: Make this specify an xcconfig data type
-      depsConfig = "#include \"" ++ xcodeConfigFile ++ "\"\n\nSKIP_INSTALL=YES\n\n" ++ fromMaybe "" depsOnlyConfig 
+      depsConfig = "#include \"" ++ xcodeConfigFile ++ "\"\n\nSKIP_INSTALL=YES\nSDKROOT=iphoneos\n\n" ++ fromMaybe "" depsOnlyConfig 
       resources = mapMaybe resourceLink kitsContents
    in KitProject pf header config depsConfig resources
   where createProjectFile cs = let

--- a/Kit/Xcode/ProjectFileTemplate.hs
+++ b/Kit/Xcode/ProjectFileTemplate.hs
@@ -96,12 +96,10 @@ buildConfigurations libDirs = let libSearch = librarySearchPaths libDirs in [
                                                     "GCC_C_LANGUAGE_STANDARD" ~> val "c99",
                                                     "GCC_OPTIMIZATION_LEVEL" ~> val "0",
                                                     "OTHER_LDFLAGS" ~> val "-ObjC",
-                                                    "SDKROOT" ~> val "iphoneos",
                                                     libSearch ]
                                             , buildConfiguration "Release" (Just kitConfigRefUUID) [
                                                     "GCC_C_LANGUAGE_STANDARD" ~> val "c99",
                                                     "OTHER_LDFLAGS" ~> val "-ObjC",
-                                                    "SDKROOT" ~> val "iphoneos",
                                                     libSearch
                                                   ]],
               "defaultConfigurationIsVisible" ~> val "0",

--- a/kit.cabal
+++ b/kit.cabal
@@ -1,5 +1,5 @@
 name:           kit
-version:        0.7.12
+version:        0.7.13
 cabal-version:  >=1.6
 build-type:     Simple
 license:        BSD3


### PR DESCRIPTION
The precompiled header file now conditionally includes Cocoa for Mac and UIKit for iOS.

Moved the SDKROOT setting to the DepsOnly.xcconfig file so that it can be overridden by the settings in MyProjectAndKits.xcconfig or KitsOnly.xcconfig.
